### PR TITLE
Add blog post: Stepping Back Into Individual Contributor Work Is Not a Step Back

### DIFF
--- a/_posts/2026-07-12-from-leader-to-individual-contributor.md
+++ b/_posts/2026-07-12-from-leader-to-individual-contributor.md
@@ -1,0 +1,47 @@
+---
+layout: post
+title: "Stepping Back Into Individual Contributor Work — Not a Step Back"
+subtitle: "Why I traded a leadership title for more time with my family"
+date: 2026-07-12
+author: Aneel Dadani
+tags: [Leadership, Career, Management]
+---
+
+A few months ago, I stepped down from a senior leadership role and moved back into an individual contributor position. When I tell people this, I can usually see the same question forming behind their eyes before they ask it out loud: "Is everything okay?" There's an assumption baked into that question — that going from leading a team back to being an individual contributor must be a demotion, a setback, or a sign that something went wrong. I want to answer that honestly: nothing went wrong. This was a decision I made deliberately, and I want to share how I got there, because I know I'm not the only leader who's quietly wrestled with this same tradeoff.
+
+## What Leadership Gave Me
+
+I want to be clear about something up front: I loved being a leader. Over more than five years in senior leadership roles, I got to set strategy, build teams from the ground up, and watch people I mentored grow into roles I knew they were capable of long before they believed it themselves. There's a specific kind of satisfaction in that — in multiplying your impact through other people instead of just your own two hands. This post isn't a story about leadership being bad, or about burning out on managing people. It's a story about timing, and about what I actually wanted this season of my life to look like.
+
+## The Real Strain
+
+For the last stretch of my leadership career, I managed a global team. On paper, that's a great career accomplishment. In practice, it meant my calendar didn't respect a single time zone. Standups with one region meant being online before sunrise. 1:1s and exec syncs with another meant staying logged on well after dinner. Strategic thinking — the kind of deep, uninterrupted work that leadership actually requires — had to get squeezed into whatever gaps were left, which usually meant early mornings or late nights.
+
+Here's the thing about leadership work: it doesn't compress into a tidy 9-to-5. It bleeds into the edges of the day. And those edges — early morning, evening, the in-between moments — are exactly the hours my two-year-old needed me most. I found myself constantly triangulating between three things that all mattered deeply to me: setting the strategic direction my team needed, being genuinely present and supportive for the people I managed, and being home and available for my family. I could usually manage two out of three on any given day. All three, consistently, started to feel impossible.
+
+## The Turning Point
+
+For a long time, my definition of success was climbing the ladder — more scope, bigger teams, higher titles. It's a definition a lot of us absorb early and never really question. What changed it for me was growing my family. Once I had a daughter who needed me present, not just provided for, the ladder stopped being the obvious answer to "what does success look like." I started noticing that I'd heard other leaders make this exact same move — stepping back from management into IC work — and I never once thought less of them for it. That was the moment I realized I was allowed to extend myself the same grace. Presence with my kid right now isn't time I can bank and spend later. This is the only version of her at two years old I'll ever get.
+
+## Not a Step Back — a Step Toward
+
+Here's the reframe I keep coming back to: this wasn't a step back, it was a step toward something. Title and scope are external metrics — things other people can see and rank. What I actually wanted was internal alignment — a life that matched what mattered to me in this specific season. Choosing that isn't giving up on ambition; it's redirecting it toward a goal that a job title was never going to capture anyway.
+
+I also want to be clear this isn't a permanent goodbye to leadership. I'm not closing that door — I fully expect I'll lead a team again if the right opportunity comes along at the right time. But "the right time" isn't right now, and I'm at peace with that. This is a "for now," not a "forever."
+
+## What's Changed Since
+
+The transition itself took some adjusting. There's an identity shift that comes with going from "the person who sets direction" back to "the person who executes it" — I won't pretend that was instant or entirely comfortable. But there's also been a lot that's surprisingly good: I get to go deep on the work itself again instead of always operating one layer removed from it. My calendar finally fits inside a normal day. And I'm home for the parts of my daughter's day that used to belong to a standup on the other side of the world.
+
+## If You're Considering This Move
+
+A few things I'd offer to anyone quietly wondering if this is the right call for them too:
+
+1. **Define success on your own terms, not the org chart's.** The next title up is only a win if it actually gets you closer to what you want your life to look like.
+2. **Talk to people who've made this move.** Ask them how it went, honestly. Normalizing the conversation is half the battle — I wish I'd asked sooner.
+3. **Get clear on your "why" before you make the change.** You'll need to explain it — to your manager, to your team, and mostly to yourself — and it's a lot easier to do that without apology when you're clear on the reason.
+4. **Remember it's a season, not a life sentence.** Leadership can be a door you walk back through later. Deciding to step away now doesn't mean deciding forever.
+
+---
+
+*If you're going through this same transition or thinking about it, I'd genuinely love to hear from you. Feel free to reach out — my LinkedIn and GitHub links are below.*

--- a/_posts/2026-07-12-from-leader-to-individual-contributor.md
+++ b/_posts/2026-07-12-from-leader-to-individual-contributor.md
@@ -39,7 +39,7 @@ I still have ambitions well beyond this role too, including wanting to run my ow
 
 ## What's Changed Since
 
-The transition itself took some adjusting. There's an identity shift that comes with going from "the person who sets direction" back to "the person who executes it." I won't pretend that was instant or entirely comfortable. But there's also been a lot that's surprisingly good: I get to go deep on the work itself again instead of always operating one layer removed from it. My calendar finally fits inside a normal day. And I'm home for the parts of my daughter's day that used to belong to a standup on the other side of the world.
+The transition itself took some adjusting. There's an identity shift that comes with going from "the person who sets direction" back to "the person who executes it." I won't pretend that was instant or entirely comfortable. But there's also been a lot that's surprisingly good: I get to go deep on the work itself again instead of always operating one layer removed from it. My calendar finally fits inside a normal day. And I'm present for the parts of my daughter's day that used to belong to a standup on the other side of the world.
 
 ## If You're Considering This Move
 

--- a/_posts/2026-07-12-from-leader-to-individual-contributor.md
+++ b/_posts/2026-07-12-from-leader-to-individual-contributor.md
@@ -15,6 +15,8 @@ I want to be clear about something up front: I loved being a leader. Over more t
 
 ## The Real Strain
 
+About two years ago, our family grew — I became a dad. That was the first time in my life I had to learn how to balance family life with work life, and it's a balance I've been working at, imperfectly, ever since.
+
 In my last leadership role, I managed a global team. On paper, that's a great career accomplishment. In practice, it meant my calendar didn't respect a single time zone. Standups with one region meant being online before sunrise. 1:1s and exec syncs with another meant staying logged on well after dinner. Strategic thinking — the kind of deep, uninterrupted work that leadership actually requires — had to get squeezed into whatever gaps were left, which usually meant early mornings or late nights.
 
 Here's the thing about leadership work: it doesn't compress into a tidy 9-to-5. It bleeds into the edges of the day. And those edges — early morning, evening, the in-between moments — are exactly the hours my two-year-old needed me most. I found myself constantly triangulating between three things that all mattered deeply to me: setting the strategic direction my team needed, being genuinely present and supportive for the people I managed, and being home and available for my family. I could usually manage two out of three on any given day. All three, consistently, started to feel impossible.

--- a/_posts/2026-07-12-from-leader-to-individual-contributor.md
+++ b/_posts/2026-07-12-from-leader-to-individual-contributor.md
@@ -1,51 +1,57 @@
 ---
 layout: post
-title: "Stepping Back Into Individual Contributor Work — Not a Step Back"
+title: "Stepping Back Into Individual Contributor Work Is Not a Step Back"
 subtitle: "Why I went looking for an individual contributor role instead of my next leadership title"
 date: 2026-07-12
 author: Aneel Dadani
 tags: [Leadership, Career, Management]
 ---
 
-A few months ago, I found myself back on the job market after several years in senior leadership. Here's the part that surprises people: I wasn't looking for my next leadership title. I went looking for an individual contributor role, on purpose. When I tell people that, I can usually see the same question forming behind their eyes before they ask it out loud: "Wait, why would you go backwards?" There's an assumption baked into that question — that choosing IC work over leadership must be a step down, or a consolation prize. I want to answer that honestly: it wasn't either. This was a decision I made deliberately, and I want to share how I got there, because I know I'm not the only leader who's quietly wrestled with this same tradeoff.
+A few months ago, I found myself back on the job market after several years in senior leadership. Here's the part that surprises people: I wasn't looking for my next leadership title. I went looking for an individual contributor role, on purpose. When I tell people that, I can usually see the same question forming behind their eyes before they ask it out loud: "Wait, why would you go backwards?" There's an assumption baked into that question: that choosing IC work over leadership must be a step down, or a consolation prize. I want to answer that honestly: it wasn't either. This was a decision I made deliberately, and I want to share how I got there, because I know I'm not the only leader who's quietly wrestled with this same tradeoff.
 
 ## What Leadership Gave Me
 
-I want to be clear about something up front: I loved being a leader. Over more than five years in senior leadership roles, I got to set strategy, build teams from the ground up, and watch people I mentored grow into roles I knew they were capable of long before they believed it themselves. There's a specific kind of satisfaction in that — in multiplying your impact through other people instead of just your own two hands. So when I started applying to roles again, it wasn't because I'd soured on leadership. It's a story about timing, and about what I actually wanted this season of my life to look like.
+I want to be clear about something up front: I loved being a leader. Over more than five years in senior leadership roles, I got to set strategy, build teams from the ground up, and watch people I mentored grow into roles I knew they were capable of long before they believed it themselves. There's a specific kind of satisfaction in that: multiplying your impact through other people instead of just your own two hands. So when I started applying to roles again, it wasn't because I'd soured on leadership. It's a story about timing, and about what I actually wanted this season of my life to look like.
 
 ## The Real Strain
 
-About two years ago, our family grew — I became a dad. That was the first time in my life I had to learn how to balance family life with work life, and it's a balance I've been working at, imperfectly, ever since.
+About two years ago, our family grew. I became a dad. That was the first time in my life I had to learn how to balance family life with work life, and it's a balance I've been working at, imperfectly, ever since.
 
-In my last leadership role, I managed a global team. On paper, that's a great career accomplishment. In practice, it meant my calendar didn't respect a single time zone. Standups with one region meant being online before sunrise. 1:1s and exec syncs with another meant staying logged on well after dinner. Strategic thinking — the kind of deep, uninterrupted work that leadership actually requires — had to get squeezed into whatever gaps were left, which usually meant early mornings or late nights.
+In my last leadership role, I managed a global team. On paper, that's a great career accomplishment. In practice, it meant my calendar didn't respect a single time zone. Standups with one region meant being online before sunrise. 1:1s and exec syncs with another meant staying logged on well after dinner. Strategic thinking (the kind of deep, uninterrupted work that leadership actually requires) had to get squeezed into whatever gaps were left, which usually meant early mornings or late nights.
 
-Here's the thing about leadership work: it doesn't compress into a tidy 9-to-5. It bleeds into the edges of the day. And those edges — early morning, evening, the in-between moments — are exactly the hours my two-year-old needed me most. I found myself constantly triangulating between three things that all mattered deeply to me: setting the strategic direction my team needed, being genuinely present and supportive for the people I managed, and being home and available for my family. I could usually manage two out of three on any given day. All three, consistently, started to feel impossible.
+Here's the thing about leadership work: it doesn't compress into a tidy 9-to-5. It bleeds into the edges of the day. And those edges (early morning, evening, the in-between moments) are exactly the hours my family needed me the most. I found myself constantly triangulating between three things that all mattered deeply to me: setting the strategic direction my team needed, being genuinely present and supportive for the people I managed, and being home and available for my family. I could usually manage two out of three on any given day. All three, consistently, started to feel impossible.
 
 ## The Turning Point
 
 So when I found myself job hunting again, I made a deliberate call: I wasn't going to target leadership roles this time around. I was going to look for individual contributor positions, on purpose.
 
-For a long time, my definition of success was climbing the ladder — more scope, bigger teams, higher titles. It's a definition a lot of us absorb early and never really question. What changed it for me was growing my family. Once I had a daughter who needed me present, not just provided for, the ladder stopped being the obvious answer to "what does success look like." I started noticing that I'd heard other leaders make this exact same move — choosing IC work over their next leadership title — and I never once thought less of them for it. That was the moment I realized I was allowed to extend myself the same grace. Presence with my kid right now isn't time I can bank and spend later. This is the only version of her at two years old I'll ever get.
+For a long time, my definition of success was climbing the ladder: more scope, bigger teams, higher titles. It's a definition a lot of us absorb early and never really question. What changed it for me was growing my family. Once I had a daughter who needed me present, not just provided for, the ladder stopped being the obvious answer to "what does success look like." I started noticing that I'd heard other leaders make this exact same move (choosing IC work over their next leadership title), and I never once thought less of them for it. That was the moment I realized I was allowed to extend myself the same grace. Presence with my kid right now isn't time I can bank and spend later. This is the only time I'll get where she actually wants to spend time with me.
 
-## Not a Step Back — a Step Toward
+That decision came with real trade-offs, and I don't want to gloss over them. Making this move meant considering a pay cut, and that wasn't an easy thing to accept. Before I committed to anything, my spouse and I sat down and talked it through openly, so that whatever number we landed on, we both knew we could live with it. If you're weighing this same move, that's worth being honest with yourself and your family about early, not after an offer is already on the table.
 
-Here's the reframe I keep coming back to: choosing IC work wasn't a step back, it was a step toward something. Title and scope are external metrics — things other people can see and rank. What I actually wanted was internal alignment — a life that matched what mattered to me in this specific season. Choosing that isn't giving up on ambition; it's redirecting it toward a goal that a job title was never going to capture anyway.
+## Not a Step Back, a Step Toward
 
-I also want to be clear this isn't a permanent goodbye to leadership. I'm not closing that door — I fully expect I'll lead a team again if the right opportunity comes along at the right time. But "the right time" isn't right now, and I'm at peace with that. This is a "for now," not a "forever."
+Here's the reframe I keep coming back to: choosing IC work wasn't a step back, it was a step toward something. Title and scope are external metrics: things other people can see and rank. What I actually wanted was internal alignment: a life that matched what mattered to me in this specific season. Choosing that isn't giving up on ambition; it's redirecting it toward a goal that a job title was never going to capture anyway.
+
+I also want to be clear this isn't a permanent goodbye to leadership. I'm not closing that door. I fully expect I'll lead a team again if the right opportunity comes along at the right time. But "the right time" isn't right now, and I'm at peace with that. This is a "for now," not a "forever."
+
+I still have ambitions well beyond this role too, including wanting to run my own business and be my own boss someday. That goal hasn't disappeared, it's just not this season's goal. Leadership, entrepreneurship, whatever comes next: it can all wait its turn without vanishing.
 
 ## What's Changed Since
 
-The transition itself took some adjusting. There's an identity shift that comes with going from "the person who sets direction" back to "the person who executes it" — I won't pretend that was instant or entirely comfortable. But there's also been a lot that's surprisingly good: I get to go deep on the work itself again instead of always operating one layer removed from it. My calendar finally fits inside a normal day. And I'm home for the parts of my daughter's day that used to belong to a standup on the other side of the world.
+The transition itself took some adjusting. There's an identity shift that comes with going from "the person who sets direction" back to "the person who executes it." I won't pretend that was instant or entirely comfortable. But there's also been a lot that's surprisingly good: I get to go deep on the work itself again instead of always operating one layer removed from it. My calendar finally fits inside a normal day. And I'm home for the parts of my daughter's day that used to belong to a standup on the other side of the world.
 
 ## If You're Considering This Move
 
 A few things I'd offer to anyone quietly wondering if this is the right call for them too:
 
 1. **Define success on your own terms, not the org chart's.** The next title up is only a win if it actually gets you closer to what you want your life to look like.
-2. **Talk to people who've made this move.** Ask them how it went, honestly. Normalizing the conversation is half the battle — I wish I'd asked sooner.
-3. **Get clear on your "why" before you start applying.** You'll need to explain it — to interviewers, to your network, and mostly to yourself — and it's a lot easier to do that without apology when you're clear on the reason.
+2. **Talk to people who've made this move.** Ask them how it went, honestly. Normalizing the conversation is half the battle. I wish I'd asked sooner.
+3. **Get clear on your "why" before you start applying.** You'll need to explain it (to interviewers, to your network, and mostly to yourself), and it's a lot easier to do that without apology when you're clear on the reason.
 4. **Remember it's a season, not a life sentence.** Leadership can be a door you walk back through later. Choosing IC work now doesn't mean choosing it forever.
+
+And if you're in the thick of the job search itself, the advice I shared in [Job Search Tips](https://aneeldadani.com/2025-07-25-job-search-tips/) still holds up here too. None of it changes just because you're targeting a different kind of role.
 
 ---
 
-*If you're going through this same transition or thinking about it, I'd genuinely love to hear from you. Feel free to reach out — my LinkedIn and GitHub links are below.*
+*If you're going through this same transition or thinking about it, I'd genuinely love to hear from you. Feel free to reach out. My LinkedIn and GitHub links are below.*

--- a/_posts/2026-07-12-from-leader-to-individual-contributor.md
+++ b/_posts/2026-07-12-from-leader-to-individual-contributor.md
@@ -1,31 +1,33 @@
 ---
 layout: post
 title: "Stepping Back Into Individual Contributor Work — Not a Step Back"
-subtitle: "Why I traded a leadership title for more time with my family"
+subtitle: "Why I went looking for an individual contributor role instead of my next leadership title"
 date: 2026-07-12
 author: Aneel Dadani
 tags: [Leadership, Career, Management]
 ---
 
-A few months ago, I stepped down from a senior leadership role and moved back into an individual contributor position. When I tell people this, I can usually see the same question forming behind their eyes before they ask it out loud: "Is everything okay?" There's an assumption baked into that question — that going from leading a team back to being an individual contributor must be a demotion, a setback, or a sign that something went wrong. I want to answer that honestly: nothing went wrong. This was a decision I made deliberately, and I want to share how I got there, because I know I'm not the only leader who's quietly wrestled with this same tradeoff.
+A few months ago, I found myself back on the job market after several years in senior leadership. Here's the part that surprises people: I wasn't looking for my next leadership title. I went looking for an individual contributor role, on purpose. When I tell people that, I can usually see the same question forming behind their eyes before they ask it out loud: "Wait, why would you go backwards?" There's an assumption baked into that question — that choosing IC work over leadership must be a step down, or a consolation prize. I want to answer that honestly: it wasn't either. This was a decision I made deliberately, and I want to share how I got there, because I know I'm not the only leader who's quietly wrestled with this same tradeoff.
 
 ## What Leadership Gave Me
 
-I want to be clear about something up front: I loved being a leader. Over more than five years in senior leadership roles, I got to set strategy, build teams from the ground up, and watch people I mentored grow into roles I knew they were capable of long before they believed it themselves. There's a specific kind of satisfaction in that — in multiplying your impact through other people instead of just your own two hands. This post isn't a story about leadership being bad, or about burning out on managing people. It's a story about timing, and about what I actually wanted this season of my life to look like.
+I want to be clear about something up front: I loved being a leader. Over more than five years in senior leadership roles, I got to set strategy, build teams from the ground up, and watch people I mentored grow into roles I knew they were capable of long before they believed it themselves. There's a specific kind of satisfaction in that — in multiplying your impact through other people instead of just your own two hands. So when I started applying to roles again, it wasn't because I'd soured on leadership. It's a story about timing, and about what I actually wanted this season of my life to look like.
 
 ## The Real Strain
 
-For the last stretch of my leadership career, I managed a global team. On paper, that's a great career accomplishment. In practice, it meant my calendar didn't respect a single time zone. Standups with one region meant being online before sunrise. 1:1s and exec syncs with another meant staying logged on well after dinner. Strategic thinking — the kind of deep, uninterrupted work that leadership actually requires — had to get squeezed into whatever gaps were left, which usually meant early mornings or late nights.
+In my last leadership role, I managed a global team. On paper, that's a great career accomplishment. In practice, it meant my calendar didn't respect a single time zone. Standups with one region meant being online before sunrise. 1:1s and exec syncs with another meant staying logged on well after dinner. Strategic thinking — the kind of deep, uninterrupted work that leadership actually requires — had to get squeezed into whatever gaps were left, which usually meant early mornings or late nights.
 
 Here's the thing about leadership work: it doesn't compress into a tidy 9-to-5. It bleeds into the edges of the day. And those edges — early morning, evening, the in-between moments — are exactly the hours my two-year-old needed me most. I found myself constantly triangulating between three things that all mattered deeply to me: setting the strategic direction my team needed, being genuinely present and supportive for the people I managed, and being home and available for my family. I could usually manage two out of three on any given day. All three, consistently, started to feel impossible.
 
 ## The Turning Point
 
-For a long time, my definition of success was climbing the ladder — more scope, bigger teams, higher titles. It's a definition a lot of us absorb early and never really question. What changed it for me was growing my family. Once I had a daughter who needed me present, not just provided for, the ladder stopped being the obvious answer to "what does success look like." I started noticing that I'd heard other leaders make this exact same move — stepping back from management into IC work — and I never once thought less of them for it. That was the moment I realized I was allowed to extend myself the same grace. Presence with my kid right now isn't time I can bank and spend later. This is the only version of her at two years old I'll ever get.
+So when I found myself job hunting again, I made a deliberate call: I wasn't going to target leadership roles this time around. I was going to look for individual contributor positions, on purpose.
+
+For a long time, my definition of success was climbing the ladder — more scope, bigger teams, higher titles. It's a definition a lot of us absorb early and never really question. What changed it for me was growing my family. Once I had a daughter who needed me present, not just provided for, the ladder stopped being the obvious answer to "what does success look like." I started noticing that I'd heard other leaders make this exact same move — choosing IC work over their next leadership title — and I never once thought less of them for it. That was the moment I realized I was allowed to extend myself the same grace. Presence with my kid right now isn't time I can bank and spend later. This is the only version of her at two years old I'll ever get.
 
 ## Not a Step Back — a Step Toward
 
-Here's the reframe I keep coming back to: this wasn't a step back, it was a step toward something. Title and scope are external metrics — things other people can see and rank. What I actually wanted was internal alignment — a life that matched what mattered to me in this specific season. Choosing that isn't giving up on ambition; it's redirecting it toward a goal that a job title was never going to capture anyway.
+Here's the reframe I keep coming back to: choosing IC work wasn't a step back, it was a step toward something. Title and scope are external metrics — things other people can see and rank. What I actually wanted was internal alignment — a life that matched what mattered to me in this specific season. Choosing that isn't giving up on ambition; it's redirecting it toward a goal that a job title was never going to capture anyway.
 
 I also want to be clear this isn't a permanent goodbye to leadership. I'm not closing that door — I fully expect I'll lead a team again if the right opportunity comes along at the right time. But "the right time" isn't right now, and I'm at peace with that. This is a "for now," not a "forever."
 
@@ -39,8 +41,8 @@ A few things I'd offer to anyone quietly wondering if this is the right call for
 
 1. **Define success on your own terms, not the org chart's.** The next title up is only a win if it actually gets you closer to what you want your life to look like.
 2. **Talk to people who've made this move.** Ask them how it went, honestly. Normalizing the conversation is half the battle — I wish I'd asked sooner.
-3. **Get clear on your "why" before you make the change.** You'll need to explain it — to your manager, to your team, and mostly to yourself — and it's a lot easier to do that without apology when you're clear on the reason.
-4. **Remember it's a season, not a life sentence.** Leadership can be a door you walk back through later. Deciding to step away now doesn't mean deciding forever.
+3. **Get clear on your "why" before you start applying.** You'll need to explain it — to interviewers, to your network, and mostly to yourself — and it's a lot easier to do that without apology when you're clear on the reason.
+4. **Remember it's a season, not a life sentence.** Leadership can be a door you walk back through later. Choosing IC work now doesn't mean choosing it forever.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a new blog post at `_posts/2026-07-12-from-leader-to-individual-contributor.md` about deliberately moving from a senior leadership role back into individual contributor work
- Covers the appreciation for leadership, the real strain of running a global team's schedule alongside family time since becoming a dad, the pay-cut trade-off discussed with a spouse, and the reframe that this is "not a step back, a step toward" (with an explicit "for now, not forever" note)
- Adds two new tags, `Leadership` and `Management`, alongside the existing `Career` tag
- Links back to the existing `Job Search Tips` post for readers navigating the job search itself

## Test plan
- [x] Built the site locally with `bundle exec jekyll build` and confirmed no errors
- [x] Verified the post renders at its expected permalink with the correct title
- [x] Verified the new `Leadership` and `Management` tags appear on the site's tag archive page


---
_Generated by [Claude Code](https://claude.ai/code/session_01CrXAeYDJ61EQDLUUJWPcEb)_